### PR TITLE
Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "trim-newlines": "^4.0.2",
     "ansi-regex": "^5.0.1",
     "json-schema": "^0.4.0",
+    "minimist": "^1.2.6",
     "trim-off-newlines": "^1.0.3",
     "shelljs": "^0.8.5"
   }

--- a/packages/data-dynamodb/src/repositories/base.ts
+++ b/packages/data-dynamodb/src/repositories/base.ts
@@ -92,8 +92,8 @@ export abstract class BaseRepository<T extends BaseObject> implements IBaseRepos
   protected async findAllByIndex(parentId: string, index: string) {
     const dataArray: Document[] = await this.getModel().query("parentId").eq(parentId)
       .where("index").beginsWith(index)
-      //@ts-ignore
-      .all().exec();
+      .all()
+      .exec();
     if (dataArray.length) {
       return dataArray.map(o => this.fromDocument(o));
     } else {
@@ -104,9 +104,8 @@ export abstract class BaseRepository<T extends BaseObject> implements IBaseRepos
   protected async findByIndex(parentId: string, index: string) {
     const data: Document[] = await this.getModel().query("parentId").eq(parentId)
       .where("index").beginsWith(index)
-      //@ts-ignore
-      // .sort("descending").limit(1)
       .sort("descending")
+      .limit(1)
       .exec();
     if (data.length) {
       return data.map(o => this.fromDocument(o))[0];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5028,12 +5028,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.3:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
- Improve error logs for `order` and `challenge`

**Order**
```
[error] 2022-06-15T08:03:15.415Z OrderService: One of order authorizations has wrong status {
  orderId: 10,
  accountId: 26,
  stack: 'AcmeError: One of order authorizations has wrong status\n' +
    '    at OrderService.refreshStatus (/Users/microshine/github/pv/acme-ts/packages/server/src/services/order.ts:197:41)\n' +
    '    at async OrderService.getById (/Users/microshine/github/pv/acme-ts/packages/server/src/services/order.ts:177:5)\n' +
    '    at async /Users/microshine/github/pv/acme-ts/packages/server/src/controllers/controller.ts:367:21\n' +
    '    at async AcmeController.wrapAction (/Users/microshine/github/pv/acme-ts/packages/server/src/controllers/controller.ts:121:7)\n' +
    '    at async Context.<anonymous> (/Users/microshine/github/pv/acme-ts/test/server/controller.ts:995:25)',
  error: Error {
    id: 0,
    type: 'urn:ietf:params:acme:error:malformed',
    detail: 'One of order authorizations has wrong status'
  }
}
```

**Challenge**
```
[error] 2022-06-15T08:03:15.415Z DnsChallengeService: Error on challenge validation {
  challenge: {
    id: 0,
    type: 'http-01'
  },
 stack: 'AcmeError\n' +
    '    at OrderService.onEnrollCertificateBefore (/Users/microshine/github/pv/acme-ts/packages/server/src/services/order.ts:451:11)\n' +
    '    at OrderService.enrollCertificate (/Users/microshine/github/pv/acme-ts/packages/server/src/services/order.ts:307:18)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n' +
    '    at async /Users/microshine/github/pv/acme-ts/packages/server/src/controllers/controller.ts:427:21\n' +
    '    at async AcmeController.wrapAction (/Users/microshine/github/pv/acme-ts/packages/server/src/controllers/controller.ts:121:7)\n' +
    '    at async Controllers.finalizeOrder (/Users/microshine/github/pv/acme-ts/packages/server-express/src/controllers/controllers.ts:62:20)',
  error: DynamoError {
    id: 'BKz0ZB5FVXKlCdw95ZVfZfc4bzQ',
    type: 'urn:ietf:params:acme:error:badPublicKey',
    detail: ''
  }
}
```
- Update `findByIndex` for Dynamo repositories.